### PR TITLE
Fix a typo

### DIFF
--- a/manuscript/fr/operation.txt
+++ b/manuscript/fr/operation.txt
@@ -1150,7 +1150,7 @@ I> clair et plus facile à comprendre.
 
 Lorsque vous codez votre site web, vous devrez souvent déclarer votre propre service dans le gestionnaire 
 de services. L'un des moyens de déclarer un service consiste à utiliser la méthode `setService()` du 
-gestionnaire de services. Par exemple, créons et déclareons la classe de service "convertisseur de devise", 
+gestionnaire de services. Par exemple, créons et déclarons la classe de service "convertisseur de devise", 
 qui sera utilisée, par exemple, sur une page de panier pour convertir la devise EUR en USD:
 
 


### PR DESCRIPTION
"déclareons" must be "déclarons". ("nous déclarons" => http://la-conjugaison.nouvelobs.com/du/verbe/declarer.php)